### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent::Plugin::InfluxDB
+# Fluent::Plugin::InfluxDB, a plugin for [Fluentd](http://fluentd.org)
 
 fluent-plugin-influxdb is a buffered output plugin for fluentd and influxDB.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
