### PR TITLE
fix adding time

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -37,10 +37,11 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
     bulk = []
 
     chunk.msgpack_each do |tag, time, record|
+      record['time'] = time unless record.has_key? 'time'
       bulk << {
         'name' => tag,
-        'columns' => record.keys << 'time',
-        'points' => [record.values << time],
+        'columns' => record.keys,
+        'points' => [record.values],
       }
     end
 


### PR DESCRIPTION
if record has time key, keys will be [time, other_key_a, other_key_b, time] and
it crashs influxdb(0.7.0).