### PR TITLE
ignore empty record for write method

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -42,8 +42,10 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
 
   def write(chunk)
     chunk.msgpack_each do |tag, time, record|
-      record[:time] = time
-      @influxdb.write_point(tag, record)
+      unless record.empty?
+        record[:time] = time
+        @influxdb.write_point(tag, record)
+      end
     end
   end
 end


### PR DESCRIPTION
Hello, thank you for the useful plugin. I found the following issue.

If there's no record when a flush occurs, some errors are recorded in the td-agent.log;

```
2015-04-01 08:27:35 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2015-04-01 08:31:57 +0000 error_class="InfluxDB::Error" error="Unable to write points without fields" plugin_id="object:3fb91b5fbdd8"
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.1.8/lib/influxdb/client.rb:234:in `block in post'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.1.8/lib/influxdb/client.rb:264:in `call'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.1.8/lib/influxdb/client.rb:264:in `connect_with_retry'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.1.8/lib/influxdb/client.rb:227:in `post'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.1.8/lib/influxdb/client.rb:170:in `_write'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.1.8/lib/influxdb/client.rb:163:in `write_point'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-influxdb-0.1.2/lib/fluent/plugin/out_influxdb.rb:46:in `block in write'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/buf_memory.rb:62:in `feed_each'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/plugin/buf_memory.rb:62:in `msgpack_each'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-influxdb-0.1.2/lib/fluent/plugin/out_influxdb.rb:44:in `write'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/buffer.rb:300:in `write_chunk'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/buffer.rb:280:in `pop'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/output.rb:316:in `try_flush'
  2015-04-01 08:27:35 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.10.61/lib/fluent/output.rb:136:in `run'
```

After applying this patch, empty records are skipped to write.

Thanks.