### PR TITLE
Force to use influxdb gem v0.1.x

### DIFF
--- a/fluent-plugin-influxdb.gemspec
+++ b/fluent-plugin-influxdb.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "fluentd"
-  s.add_runtime_dependency "influxdb"
+  s.add_runtime_dependency "fluentd", [">= 0.10.49", "< 2"]
+  s.add_runtime_dependency "influxdb", "~> 0.1.8"
 
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
Next release of influxdb gem breaks backward compatibility so
influxdb plugin 0.1.x should keep to use influxdb gem 0.1.x.