### PR TITLE
Influx 0.9 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ fluent-plugin-influxdb is a buffered output plugin for fluentd and influxDB.
 
 If you are using fluentd as a collector and want to organize your time-series data in influxDB, this is your right choice!
 
+## NOTE
+
+This version uses influxdb-ruby version 0.2.0 which no longer supports Influx version 0.8 (which is also deprecated). If you are using Influx version 0.8 please specify version 0.1.8 of this plugin.
+
 ## Installation
 
     $ fluent-gem install fluent-plugin-influxdb

--- a/fluent-plugin-influxdb.gemspec
+++ b/fluent-plugin-influxdb.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = "fluent-plugin-influxdb"
-  s.version       = '0.1.8'
+  s.version       = '0.2.0'
   s.authors       = ["Masahiro Nakagawa", "FangLi"]
   s.email         = ["repeatedly@gmail.com", "surivlee@gmail.com"]
   s.description   = %q{InfluxDB output plugin for Fluentd}
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fluentd", [">= 0.10.49", "< 2"]
-  s.add_runtime_dependency "influxdb", "~> 0.1.8"
+  s.add_runtime_dependency "influxdb", "~> 0.2.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -1,7 +1,6 @@
 # encoding: UTF-8
 require 'date'
 require 'influxdb'
-require 'fluent/mixin/mixin'
 
 class Fluent::InfluxdbOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('influxdb', self)


### PR DESCRIPTION
Move the plugin to support the current version of Influx, 0.9. I added a note to the readme about the compatibility issue with the now deprecated 0.8.