### PR TITLE
Apply to influxdb-ruby v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ fluent-plugin-influxdb is a buffered output plugin for fluentd and influxDB.
 
 If you are using fluentd as a collector and want to organize your time-series data in influxDB, this is your right choice!
 
+## NOTE
+
+This version uses influxdb-ruby version 0.2.0 which no longer supports InfluxDB version 0.8 (which is also deprecated).
+If you are using InfluxDB version 0.8 please specify version 0.1.8 of this plugin.
+
 ## Installation
 
     $ fluent-gem install fluent-plugin-influxdb

--- a/fluent-plugin-influxdb.gemspec
+++ b/fluent-plugin-influxdb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fluentd", [">= 0.10.49", "< 2"]
-  s.add_runtime_dependency "influxdb", "~> 0.1.8"
+  s.add_runtime_dependency "influxdb", ">= 0.2.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -45,17 +45,17 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
   end
 
   def write(chunk)
-    points = {}
+    points = []
     chunk.msgpack_each do |tag, time, record|
       unless record.empty?
-        record[:time] = time unless record.has_key?('time')
-        points[tag] ||= []
-        points[tag] << record
+        point = {}
+        point[:timestamp] = record.delete('time') || time
+        point[:series] = tag
+        point[:values] = record
+        points << point
       end
     end
 
-    points.each { |tag, records|
-      @influxdb.write_point(tag, records)
-    }
+    @influxdb.write_points(points)
   end
 end


### PR DESCRIPTION
In influxdb-ruby v0.2.0, this plugin doesn't work.
This PR applies to influxdb-ruby v0.2.0 for this plugin.