### PR TITLE
Add support for influxdb tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.rbc
 *.gem
 .bundle
+Gemfile.lock
+vendor/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 `time_precision`: The time precision of timestamp. default to "s". should specify either second (s), millisecond (m), or microsecond (u)
 
-`tag_keys`: The names of the keys to use as influxDB tags. Please also specify the comma-separated keys parameter.
+`tag_keys`: The names of the keys to use as influxDB tags.
 
 ### Fluentd Tag and InfluxDB Series
 
@@ -56,6 +56,7 @@ So if you have events with `app.event`, influxdb plugin inserts events into `app
   password  mypwd
   use_ssl false
   time_precision s
+  tag_keys ['key1', 'key2']
 </match>
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 `time_precision`: The time precision of timestamp. default to "s". should specify either second (s), millisecond (m), or microsecond (u)
 
+`tag_keys`: The names of the keys to use as influxDB tags. Please also specify the comma-separated keys parameter.
+
 ### Fluentd Tag and InfluxDB Series
 
 influxdb plugin uses Fluentd event tag for InfluxDB series.

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -14,9 +14,7 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
   config_param :password, :string,  :default => 'root', :secret => true
   config_param :time_precision, :string, :default => 's'
   config_param :use_ssl, :bool, :default => false
-  config_param :tag_keys, :default => [] do |val|
-    val.split(',')
-  end
+  config_param :tag_keys, :array, :default => []
 
 
   def initialize

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -52,8 +52,12 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
         point = {}
         point[:timestamp] = record.delete('time') || time
         point[:series] = tag
-        point[:tags] = record.select{|k,v| @tag_keys.include?(k)}
-        point[:values] = record.select{|k,v| !@tag_keys.include?(k)}
+        if tag_keys.empty?
+          point[:values] = record
+        else
+          point[:tags] = record.select{|k,v| @tag_keys.include?(k)}
+          point[:values] = record.select{|k,v| !@tag_keys.include?(k)}
+        end
         points << point
       end
     end

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -14,6 +14,9 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
   config_param :password, :string,  :default => 'root', :secret => true
   config_param :time_precision, :string, :default => 's'
   config_param :use_ssl, :bool, :default => false
+  config_param :tag_keys, :default => [] do |val|
+    val.split(',')
+  end
 
 
   def initialize
@@ -51,7 +54,8 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
         point = {}
         point[:timestamp] = record.delete('time') || time
         point[:series] = tag
-        point[:values] = record
+        point[:tags] = record.select{|k,v| @tag_keys.include?(k)}
+        point[:values] = record.select{|k,v| !@tag_keys.include?(k)}
         points << point
       end
     end


### PR DESCRIPTION
I added support for tags feature of InfluxDB 0.9.
In InfluxDB 0.9 we can not use field in GROUP BY clause, so I want to use tags.

Add a new optional config option `tag_keys` that automatically maps keys in the fluentd message that make sense to be used as InfuxDB tags.

```
<match mylog.*>
  type influxdb
  host  localhost
  port  8086
  dbname test
  user  testuser
  password  mypwd
  use_ssl false
  tag_keys uri,type
  time_precision s
</match>
```