### PR TITLE
Keep processing chunk even if chunk includes record with null value.

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -48,7 +48,7 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
   def write(chunk)
     points = []
     chunk.msgpack_each do |tag, time, record|
-      unless record.empty?
+      unless record.empty? or record.has_value?(nil)
         point = {}
         point[:timestamp] = record.delete('time') || time
         point[:series] = tag


### PR DESCRIPTION
I enabled this plugin to keep processing a chunk even if the chunk includes record with null value.

Without the change,  when this plugin is given a record including a null value, this plugin outputs the following error and cannot write any record to InfluxDB until deletion of the record.

```
2015-10-21 17:21:33 +0900 [warn]: temporarily failed to flush the buffer. next_retry=2015-10-21 17:23:43 +0900 error_class="InfluxDB::Error" error="unable to parse 'test,status= count=2 144541429
1': missing tag value\n" plugin_id="object:1ebf6a8"
```