### PR TITLE
Fix description of time_precision (millisecond=ms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 `use_ssl`: Use SSL when connecting to influxDB. default to false
 
-`time_precision`: The time precision of timestamp. default to "s". should specify either second (s), millisecond (m), or microsecond (u)
+`time_precision`: The time precision of timestamp. default to "s". should specify either hour (h), minutes (m), second (s), millisecond (ms), microsecond (u), or nanosecond (n)
 
 `tag_keys`: The names of the keys to use as influxDB tags.
 


### PR DESCRIPTION
When you want to store times in milliseconds, you need to specify `ms`, not `m`.

https://influxdb.com/docs/v0.9/write_protocols/write_syntax.html#http
> precision=[n,u,ms,s,m,h] - sets the precision of the supplied Unix time values. If not present timestamps are assumed to be in nanoseconds