### PR TITLE
Don't send empty tags or values to InfluxDB

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -60,8 +60,8 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
       if tag_keys.empty?
         point[:values] = record
       else
-        point[:tags] = record.select{|k,v| @tag_keys.include?(k)}
-        point[:values] = record.select{|k,v| !@tag_keys.include?(k)}
+        point[:tags] = record.select{|k,v| @tag_keys.include?(k) && !v.empty?}
+        point[:values] = record.select{|k,v| !@tag_keys.include?(k) && !v.empty?}
       end
       points << point
     end


### PR DESCRIPTION
If receiving a syslog message that has the **ident** field empty the influxdb plugin will try to send the following line:

    syslog,host=fwtpcore1b,ident= message=\"BLAHBLAHBLAH\" 1449233580

The fact that the **ident** tag is empty results in this error:

    2015-12-04 08:22:42 -0500 [warn]: temporarily failed to flush the buffer. next_retry=2015-12-04 08:22:44 -0500 error_class="InfluxDB::Error" error="partial write:\nunable to parse 'syslog,host=fwtpcore1b,ident= message=\"BLAHBLAHBLAH\" 1449233580': missing tag value\n" plugin_id="object:166e6d4"

The change makes sure an empty tag or field/value is never written out to InfluxDB.