### PR TITLE
Add config descriptions

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -7,15 +7,34 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
 
   include Fluent::HandleTagNameMixin
 
-  config_param :host, :string,  :default => 'localhost'
-  config_param :port, :integer,  :default => 8086
-  config_param :dbname, :string,  :default => 'fluentd'
-  config_param :user, :string,  :default => 'root'
-  config_param :password, :string,  :default => 'root', :secret => true
-  config_param :time_precision, :string, :default => 's'
-  config_param :use_ssl, :bool, :default => false
-  config_param :tag_keys, :array, :default => []
-  config_param :sequence_tag, :string, :default => nil
+  config_param :host, :string,  :default => 'localhost',
+               :desc => "The IP or domain of influxDB."
+  config_param :port, :integer,  :default => 8086,
+               :desc => "The HTTP port of influxDB."
+  config_param :dbname, :string,  :default => 'fluentd',
+               :desc => <<-DESC
+The database name of influxDB.
+You should create the database and grant permissions at first.
+DESC
+  config_param :user, :string,  :default => 'root',
+               :desc => "The DB user of influxDB, should be created manually."
+  config_param :password, :string,  :default => 'root', :secret => true,
+               :desc => "The password of the user."
+  config_param :time_precision, :string, :default => 's',
+               :desc => <<-DESC
+The time precision of timestamp.
+You should specify either hour (h), minutes (m), second (s),
+millisecond (ms), microsecond (u), or nanosecond (n).
+DESC
+  config_param :use_ssl, :bool, :default => false,
+               :desc => "Use SSL when connecting to influxDB."
+  config_param :tag_keys, :array, :default => [],
+               :desc => "The names of the keys to use as influxDB tags."
+  config_param :sequence_tag, :string, :default => nil,
+               :desc => <<-DESC
+The name of the tag whose value is incremented for the consecutive simultaneous
+events and reset to zero for a new event with the different timestamp.
+DESC
 
 
   def initialize


### PR DESCRIPTION
With fluentd 0.12.19, config descriptions are shown like this:

```log
$ bundle exec fluentd --show-plugin-config output:influxdb -p lib/fluent/plugin/
2016-01-13 11:59:09 +0900 [info]: Show config for output:influxdb
2016-01-13 11:59:09 +0900 [info]: 
log_level: string: <nil> # Allows the user to set different levels of logging for each plugin.
buffer_type: string: <"memory">
flush_interval: time: <60>
try_flush_interval: float: <1>
disable_retry_limit: bool: <false>
retry_limit: integer: <17>
retry_wait: time: <1.0>
max_retry_wait: time: <nil>
num_threads: integer: <1>
queued_chunk_flush_interval: time: <1>
host: string: <"localhost"> # The IP or domain of influxDB.
port: integer: <8086> # The HTTP port of influxDB.
dbname: string: <"fluentd"> # The database name of influxDB.
You should create the database and grant permissions at first.

user: string: <"root"> # The DB user of influxDB, should be created manually.
password: string: <"root"> # The password of the user.
time_precision: string: <"s"> # The time precision of timestamp.
You should specify either hour (h), minutes (m), second (s),
millisecond (ms), microsecond (u), or nanosecond (n).

use_ssl: bool: <false> # Use SSL when connecting to influxDB.
tag_keys: array: <[]> # The names of the keys to use as influxDB tags.
sequence_tag: string: <nil> # The name of the tag whose value is incremented for the consecutive simultaneous
events and reset to zero for a new event with the different timestamp.
```