### PR TITLE
Add an option to enable/disable SSL Certs verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 `use_ssl`: Use SSL when connecting to influxDB. default to false
 
+`verify_ssl`: Enable/Disable SSL Certs verification when connecting to influxDB via SSL. default to true
+
 `time_precision`: The time precision of timestamp. default to "s". should specify either hour (h), minutes (m), second (s), millisecond (ms), microsecond (u), or nanosecond (n)
 
 `tag_keys`: The names of the keys to use as influxDB tags.

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -28,6 +28,8 @@ millisecond (ms), microsecond (u), or nanosecond (n).
 DESC
   config_param :use_ssl, :bool, :default => false,
                :desc => "Use SSL when connecting to influxDB."
+  config_param :verify_ssl, :bool, :default => true,
+               :desc => "Enable/Disable SSL Certs verification when connecting to influxDB via SSL."
   config_param :tag_keys, :array, :default => [],
                :desc => "The names of the keys to use as influxDB tags."
   config_param :sequence_tag, :string, :default => nil,
@@ -51,7 +53,8 @@ DESC
                                               password: @password,
                                               async: false,
                                               time_precision: @time_precision,
-                                              use_ssl: @use_ssl
+                                              use_ssl: @use_ssl,
+                                              verify_ssl: @verify_ssl
   end
 
   def start


### PR DESCRIPTION
This option enables to skip SSL Certs verification. It's needed to connect InfluxDB using self-signed SSL Cert.