### PR TITLE
Add verification for config

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -55,6 +55,14 @@ DESC
                                               time_precision: @time_precision,
                                               use_ssl: @use_ssl,
                                               verify_ssl: @verify_ssl
+    
+    existing_databases = @influxdb.list_databases.map { |x| x['name'] }
+    if existing_databases.include? @dbname
+        $log.info 'Dababase ' + @dbname + ' exists'
+    else
+        raise Fluent::ConfigError, 'Database ' + @dbname + ' doesn\'t exist. Create it first, please. Existing databases: ' + existed.join(",")
+    end
+    
   end
 
   def start

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -60,7 +60,7 @@ DESC
     if existing_databases.include? @dbname
         $log.info 'Dababase ' + @dbname + ' exists'
     else
-        raise Fluent::ConfigError, 'Database ' + @dbname + ' doesn\'t exist. Create it first, please. Existing databases: ' + existed.join(",")
+        raise Fluent::ConfigError, 'Database ' + @dbname + ' doesn\'t exist. Create it first, please. Existing databases: ' + existing_databases.join(",")
     end
     
   end

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -55,14 +55,24 @@ DESC
                                               time_precision: @time_precision,
                                               use_ssl: @use_ssl,
                                               verify_ssl: @verify_ssl
-    
+
+    $log.info "Connecting to database: #{@dbname}, host: #{@host}, port: #{@port}, username: #{@user}, password = #{@password}, use_ssl = #{@use_ssl}, verify_ssl = #{@verify_ssl}"
+
+    @influxdb = InfluxDB::Client.new @dbname, host: @host,
+                                     port: @port,
+                                     username: @user,
+                                     password: @password,
+                                     async: false,
+                                     time_precision: @time_precision,
+                                     use_ssl: @use_ssl,
+                                     verify_ssl: @verify_ssl
+
     existing_databases = @influxdb.list_databases.map { |x| x['name'] }
-    if existing_databases.include? @dbname
-        $log.info 'Dababase ' + @dbname + ' exists'
-    else
-        raise Fluent::ConfigError, 'Database ' + @dbname + ' doesn\'t exist. Create it first, please. Existing databases: ' + existing_databases.join(",")
+
+    unless existing_databases.include? @dbname
+      raise Fluent::ConfigError, 'Database ' + @dbname + ' doesn\'t exist. Create it first, please. Existing databases: ' + existing_databases.join(',')
     end
-    
+
   end
 
   def start


### PR DESCRIPTION
I spent more than 2 hours to understand what's going on... In my case it was incorrect certificate, but plugin doesn't tell me anything about it. Just stuck silent.
So, I added some `fail fast` verification. If connection to db couldn't be established, plugin will return InfluxDB exception, and `fluentd` will print it.
Also it checks that db already exists.