### PR TITLE
Ensure the tag has a value before attempting to write it

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -88,7 +88,10 @@ DESC
         tags = {}
         record.each_pair do |k, v|
           if @tag_keys.include?(k)
-            tags[k] = v
+            # If the tag value is not nil, empty, or a space, add the tag
+            if v.to_s.strip != ''
+              tags[k] = v
+            end
           else
             values[k] = v
           end


### PR DESCRIPTION
### Problem: 

_Somewhat defined in #37, but leaving notes here for prosperity._

When using `tag_keys` to signify keys that should be written as influxdb tags, it's possible that an event with a `nil` or `''` tag value will cause this plugin to block the entire queue from being flushed to influx.

### Background
Points are buffered in memory (by default), and then flushed to influxdb using `#write_points`. The buffer contents are posted using a single request. One erroneous record within the buffer can cause the queue buffer to grow in size (_hellooo memory leak!_) and also blocks the queue until fluentd is restarted.  With a disk-stored buffer, this could become unrecoverable until the buffer was manually removed.

### What this change does
A check to ensure that a tag value is "not blank" (that is, not nil or an empty string). If the value is "blank", then the tag will not be applied. 

Addresses #37 
Ping @repeatedly @radcool