### PR TITLE
Now it's possible to use custom tag as timestamp

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -20,6 +20,8 @@ DESC
                :desc => "The DB user of influxDB, should be created manually."
   config_param :password, :string,  :default => 'root', :secret => true,
                :desc => "The password of the user."
+  config_param :timestamp_tag, :string, :default => 'time',
+               :desc => 'Use value of this tag if it exists in event instead of event timestamp'
   config_param :time_precision, :string, :default => 's',
                :desc => <<-DESC
 The time precision of timestamp.
@@ -88,7 +90,7 @@ DESC
   def write(chunk)
     points = []
     chunk.msgpack_each do |tag, time, record|
-      timestamp = record.delete('time') || time
+      timestamp = record.delete(@timestamp_tag).to_i || time
       if tag_keys.empty?
         values = record
         tags = {}

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -20,7 +20,7 @@ DESC
                :desc => "The DB user of influxDB, should be created manually."
   config_param :password, :string,  :default => 'root', :secret => true,
                :desc => "The password of the user."
-  config_param :timestamp_tag, :string, :default => 'time',
+  config_param :time_key, :string, :default => 'time',
                :desc => 'Use value of this tag if it exists in event instead of event timestamp'
   config_param :time_precision, :string, :default => 's',
                :desc => <<-DESC
@@ -90,7 +90,7 @@ DESC
   def write(chunk)
     points = []
     chunk.msgpack_each do |tag, time, record|
-      timestamp = record.delete(@timestamp_tag).to_i || time
+      timestamp = record.delete(@time_key).to_i || time
       if tag_keys.empty?
         values = record
         tags = {}


### PR DESCRIPTION
Sometimes use can have some source of data that prints it own timestamp, so it doesn't make any sense to override it by fluent timestamps. Your plugin already had support for such cases, but timestamp name was hardcoded. I moved it to a parameter.