### PR TITLE
Add a missing require fluent/mixin

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 require 'date'
 require 'influxdb'
+require 'fluent/mixin'
 
 class Fluent::InfluxdbOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('influxdb', self)


### PR DESCRIPTION
Otherwise, this plugin seems to be ready for fluentd 0.14.0.rc.3 and 0.12.x.