### PR TITLE
Support multiple host

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 **Options:**
 
-`host`: The IP or domain of influxDB, default to "localhost"
+`host`: The IP or domain of influxDB, separate with comma, default to "localhost"
 
 `port`: The HTTP port of influxDB, default to 8086
 

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -9,7 +9,7 @@ class Fluent::InfluxdbOutput < Fluent::BufferedOutput
   include Fluent::HandleTagNameMixin
 
   config_param :host, :string,  :default => 'localhost',
-               :desc => "The IP or domain of influxDB."
+               :desc => "The IP or domain of influxDB, separate with comma."
   config_param :port, :integer,  :default => 8086,
                :desc => "The HTTP port of influxDB."
   config_param :dbname, :string,  :default => 'fluentd',
@@ -64,7 +64,7 @@ DESC
     $log.info "Connecting to database: #{@dbname}, host: #{@host}, port: #{@port}, username: #{@user}, use_ssl = #{@use_ssl}, verify_ssl = #{@verify_ssl}"
 
     # ||= for testing.
-    @influxdb ||= InfluxDB::Client.new @dbname, host: @host,
+    @influxdb ||= InfluxDB::Client.new @dbname, hosts: @host.split(','),
                                                 port: @port,
                                                 username: @user,
                                                 password: @password,


### PR DESCRIPTION
Hi
influxdb-ruby can set multple host.

https://github.com/influxdata/influxdb-ruby/blob/47faae7a64b2abaabf7c9a4b093b16a2ee34a865/lib/influxdb/config.rb#L97-L99

please check it.