### PR TITLE
Adding auto tagging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 `time_precision`: The time precision of timestamp. default to "s". should specify either hour (h), minutes (m), second (s), millisecond (ms), microsecond (u), or nanosecond (n)
 
+`auto_tags`: Enable/Disable auto-tagging behaviour which makes strings tags.
+
 `tag_keys`: The names of the keys to use as influxDB tags.
 
 `sequence_tag`: The name of the tag whose value is incremented for the consecutive simultaneous events and reset to zero for a new event with the different timestamp

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -114,7 +114,7 @@ DESC
         values = {}
         tags = {}
         record.each_pair do |k, v|
-          if @auto_tags and v.is_a? String or @tag_keys.include?(k)
+          if (@auto_tags && v.is_a?(String)) || @tag_keys.include?(k)
             # If the tag value is not nil, empty, or a space, add the tag
             if v.to_s.strip != ''
               tags[k] = v

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -36,6 +36,8 @@ DESC
                :desc => "Use SSL when connecting to influxDB."
   config_param :verify_ssl, :bool, :default => true,
                :desc => "Enable/Disable SSL Certs verification when connecting to influxDB via SSL."
+  config_param :auto_tags, :bool, :default => false,
+               :desc => "Enable/Disable auto-tagging behaviour which makes strings tags."
   config_param :tag_keys, :array, :default => [],
                :desc => "The names of the keys to use as influxDB tags."
   config_param :sequence_tag, :string, :default => nil,
@@ -105,14 +107,14 @@ DESC
     points = []
     chunk.msgpack_each do |tag, time, record|
       timestamp = record.delete(@time_key) || time
-      if tag_keys.empty?
+      if tag_keys.empty? && !@auto_tags
         values = record
         tags = {}
       else
         values = {}
         tags = {}
         record.each_pair do |k, v|
-          if @tag_keys.include?(k)
+          if @auto_tags and v.is_a? String or @tag_keys.include?(k)
             # If the tag value is not nil, empty, or a space, add the tag
             if v.to_s.strip != ''
               tags[k] = v

--- a/test/plugin/test_out_influxdb.rb
+++ b/test/plugin/test_out_influxdb.rb
@@ -149,6 +149,50 @@ class InfluxdbOutputTest < Test::Unit::TestCase
     ], driver.instance.influxdb.points)
   end
 
+  def test_auto_tagging
+    config_with_tags = %Q(
+      #{CONFIG}
+
+      auto_tags true
+    )
+
+    driver = create_driver(config_with_tags, 'input.influxdb')
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    driver.emit({'a' => 1, 'b' => '1'}, time)
+    driver.emit({'a' => 2, 'b' => 1}, time)
+    driver.emit({'a' => 3, 'b' => ' '}, time)
+
+    data = driver.run
+
+    assert_equal([
+      [
+        [
+          {
+            :timestamp => time,
+            :series    => 'input.influxdb',
+            :values    => {'a' => 1},
+            :tags      => {'b' => '1'},
+          },
+          {
+            :timestamp => time,
+            :series    => 'input.influxdb',
+            :values    => {'a' => 2, 'b' => 1},
+            :tags      => {},
+          },
+          {
+            :timestamp => time,
+            :series    => 'input.influxdb',
+            :values    => {'a' => 3},
+            :tags      => {},
+          },
+        ],
+        nil,
+        nil
+      ]
+    ], driver.instance.influxdb.points)
+  end  
+
   def test_seq
     config = %[
       type influxdb


### PR DESCRIPTION
This option simplifies the handling of tags in the incoming data.

Sometimes specifying the tag_keys is not feasible due to unknown data. In such situation it comes handy if strings become tags and numbers types becomes values. Note that sender still can send numbers as string which will make them tags. 

Parameter name: `auto_tags`
Default value: `false`

ps.: I'm not very experience in ruby. I tried my best to match coding style and keep it simple. Every feedback, ideas, remarks are welcomed. 
