### PR TITLE
InfluxDB returns different responce code in v1.0 or higher

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -80,7 +80,7 @@ DESC
       unless existing_databases.include? @dbname
         raise Fluent::ConfigError, 'Database ' + @dbname + ' doesn\'t exist. Create it first, please. Existing databases: ' + existing_databases.join(',')
       end
-    rescue InfluxDB::AuthenticationError
+    rescue InfluxDB::AuthenticationError, InfluxDB::Error
       $log.info "skip database presence check because '#{@user}' user doesn't have admin privilege. Check '#{@dbname}' exists on influxdb"
     end
   end


### PR DESCRIPTION
InfluxDB response code when 'SHOW DATABASES' query is failed was changed. Please see below for more information.
https://github.com/influxdata/influxdb/issues/6959

Ruby error class in case of 403(Forbidden) is InfluxDB::Error. It also should be added to exception handling.