### PR TITLE
Skip records with empty values

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -134,7 +134,7 @@ DESC
       end
 
       if values.empty?
-          $log.info "Skip record '#{record}', because InfluxDB requires at least one value in raw"
+          $log.warn "Skip record '#{record}', because InfluxDB requires at least one value in raw"
           next
       end
 

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -134,7 +134,7 @@ DESC
       end
 
       if values.empty?
-          $log.warn "Skip record '#{record}', because InfluxDB requires at least one value in raw"
+          log.warn "Skip record '#{record}', because InfluxDB requires at least one value in raw"
           next
       end
 

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -132,6 +132,12 @@ DESC
         tags[@sequence_tag] = @seq
         @prev_timestamp = timestamp
       end
+
+      if values.empty?
+          $log.info "Skip record '#{record}', because InfluxDB requires at least one value in raw"
+          next
+      end
+
       point = {
         :timestamp => timestamp,
         :series    => tag,

--- a/test/plugin/test_out_influxdb.rb
+++ b/test/plugin/test_out_influxdb.rb
@@ -102,7 +102,6 @@ class InfluxdbOutputTest < Test::Unit::TestCase
         nil
       ]
     ], driver.instance.influxdb.points)
-
   end
 
   def test_empty_tag_keys
@@ -142,6 +141,37 @@ class InfluxdbOutputTest < Test::Unit::TestCase
             :values    => {'a' => 3},
             :tags      => {},
           },
+        ],
+        nil,
+        nil
+      ]
+    ], driver.instance.influxdb.points)
+  end
+
+ def test_ignore_empty_values
+    config_with_tags = %Q(
+      #{CONFIG}
+
+      tag_keys ["b"]
+    )
+
+    driver = create_driver(config_with_tags, 'input.influxdb')
+
+    time = Fluent::EventTime.from_time(Time.parse('2011-01-02 13:14:15 UTC'))
+    driver.emit({'b' => '3'}, time)
+    driver.emit({'a' => 2, 'b' => 1}, time)
+
+    data = driver.run
+
+    assert_equal([
+      [
+        [
+          {
+            :timestamp => time,
+            :series    => 'input.influxdb',
+            :values    => {'a' => 2},
+            :tags      => {'b' => 1},
+          }
         ],
         nil,
         nil


### PR DESCRIPTION
In this PR I address issue that happens then somebody tries to push record without any value. In this case plugin prints in logs that it doesn't make any sense to push something like that to InfluxDB and continue to work.

According official documentation:

> Fields are a required piece of InfluxDB’s data structure - you cannot have data in InfluxDB without fields.

https://docs.influxdata.com/influxdb/v1.1/concepts/key_concepts/

So, if user doesn't provide any value he receives something like:

```
  2016-11-28 13:29:40 +0000 [warn]: before_shutdown failed error="{\"error\":\"partial write:\\nunable to parse 'db_name,tag1=tag_value1,tag2=tag_value2  TIME': invalid field format\"}\n"
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.3.0/lib/influxdb/client/http.rb:84:in `resolve_error'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.3.0/lib/influxdb/client/http.rb:35:in `block in post'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.3.0/lib/influxdb/client/http.rb:53:in `connect_with_retry'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.3.0/lib/influxdb/client/http.rb:26:in `post'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.3.0/lib/influxdb/query/core.rb:62:in `write'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/influxdb-0.3.0/lib/influxdb/query/core.rb:48:in `write_points'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-influxdb-0.2.7/lib/fluent/plugin/out_influxdb.rb:158:in `write'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/buffer.rb:345:in `write_chunk'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/buffer.rb:324:in `pop'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/buf_memory.rb:94:in `block in before_shutdown'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/buf_memory.rb:90:in `before_shutdown'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/output.rb:404:in `before_shutdown'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/output.rb:160:in `block in run'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/output.rb:159:in `synchronise'
  2016-11-28 13:29:40 +0000 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/output.rb:159:in `run'
```


After that `fluentd` tries to retry... fails... try again... and queue is blocked for some time.