### PR TITLE
Add a Meaningful Warning Message for Debugging

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -103,6 +103,7 @@ DESC
   def format(tag, time, record)
     # TODO: Use tag based chunk separation for more reliability
     if record.empty? || record.has_value?(nil)
+      log.warn "Skip record '#{record}', because either record has no value or at least a value is 'nil' inside the record. "
       FORMATTED_RESULT_FOR_INVALID_RECORD
     else
       [precision_time(time), record].to_msgpack


### PR DESCRIPTION
It is important to get a log message rather than just skip the metrics directly, so that the user could debug based on this error message. For example, this InfluxDB plugin will not send the metrics to InfluxDB if one of the tag in the metrics is 'nil' and this plugin will not give any warning or error message to inform user.