### PR TITLE
added tag_keys_field

### DIFF
--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -45,7 +45,7 @@ DESC
   config_param :tag_keys, :array, default: [],
                desc: "The names of the keys to use as influxDB tags."
   config_param :tag_keys_field, :string, default: nil,
-               desc: "The names of the fields where influxdb key names are stored"
+               desc: "The name of the fields where influxdb key names are stored"
   config_param :sequence_tag, :string, default: nil,
                desc: <<-DESC
 The name of the tag whose value is incremented for the consecutive simultaneous

--- a/test/plugin/test_out_influxdb.rb
+++ b/test/plugin/test_out_influxdb.rb
@@ -169,6 +169,35 @@ class InfluxdbOutputTest < Test::Unit::TestCase
     ], driver.instance.influxdb.points)
   end
 
+  def test_empty_tag_keys_field
+    config_with_tags = %Q(
+      #{CONFIG}
+      tag_keys_field b
+    )
+
+    driver = create_driver(config_with_tags)
+
+    time = event_time("2011-01-02 13:14:15 UTC")
+    driver.run(default_tag: 'input.influxdb') do
+      driver.feed(time, {'b' => {'a' => "2"}, 'c' => '2'})
+    end
+
+    assert_equal([
+      [
+        [
+          {
+            timestamp: 1293974055,
+            series: 'input.influxdb',
+            values: {'c' => "2"},
+            tags: {'a' => "2"}
+          },
+        ],
+        nil,
+        nil
+      ]
+    ], driver.instance.influxdb.points)
+  end
+
   def test_empty_tag_keys
     config_with_tags = %Q(
       #{CONFIG}


### PR DESCRIPTION
This pull request is to address https://github.com/fangli/fluent-plugin-influxdb/issues/75

In the issue it was suggested to use 'tag_keys_field' to point to a element which contains list of fields which should be set as tags.
But the implementation used in this pull request is that 'tag_keys_field' will point to an hash element which contains key/value pair.
This small deviation is taken due to the performance reason. Getting list of tag names, adding them to the tags and then deleting them from the fields takes too much time and is impacting scenarios at scale.
Hence this implementation where 'tag_keys_field' will point to an hash element which contains key/value pair.