### PR TITLE
Cast all integers to float

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 `retention_policy_key`: The name of the key in the record whose value specifies the retention policy.  The default retention policy will be applied if no such key exists.  influxdb >= 0.2.3 is required to use this functionality.
 
+`cast_number_to_float`: Enable/Disable casting number to float
+
 ### Fluentd Tag and InfluxDB Series
 
 influxdb plugin uses Fluentd event tag for InfluxDB series.

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -53,7 +53,9 @@ DESC
                desc: "The key of the key in the record that stores the retention policy name"
   config_param :default_retention_policy, :string, default: nil,
                desc: "The name of the default retention policy"
-
+  config_param :cast_number_to_float, :bool, default: false,
+               desc: "Enable/Disable casting number to float"
+  
   config_section :buffer do
     config_set_default :@type, DEFAULT_BUFFER_TYPE
     config_set_default :chunk_keys, ['tag']
@@ -160,9 +162,11 @@ DESC
           next
       end
       
-      values.each do |key, value|
-        if value.is_a?(Integer)
-          values[key] = Float(value)
+      if @cast_number_to_float
+        values.each do |key, value|
+          if value.is_a?(Integer)
+            values[key] = Float(value)
+          end
         end
       end
 

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -159,6 +159,12 @@ DESC
           log.warn "Skip record '#{record}', because InfluxDB requires at least one value in raw"
           next
       end
+      
+      values.each do |key, value|
+        if value.is_a?(Integer)
+          values[key] = Float(value)
+        end
+      end
 
       point = {
         timestamp: timestamp,


### PR DESCRIPTION
Hello,

To avoid `Error 'field type conflict'` integer/float because of `json` parser, we can store all the numeric value as float by default.