### PR TITLE
Auth options required to support forwarding to Telegraf's influxdb_listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 `cast_number_to_float`: Enable/Disable casting number to float. influxdb can't mix integer/float value in one measurement. If your pipeline can't unify record value, this parameter may help. Avoid 'field type conflict' error.
 
+`skip_db_check`: Skip testing if `dbname` exists on the database before attempting to write. Setting to "true" is required if your destination is a Telegraf InfluxDB Input plugin.
+
 ### Fluentd Tag and InfluxDB Series
 
 influxdb plugin uses Fluentd event tag for InfluxDB series.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Just like other regular output plugins, Use type `influxdb` in your fluentd conf
 
 `password`: The password of the user, default to "root"
 
+`auth_method`: The authentication method, default to "param". You may prefer "basic_auth" to prevent leaking of credentials in request logs.
+
 `retry`: The finite number of retry times. default is infinite
 
 `use_ssl`: Use SSL when connecting to influxDB. default to false
@@ -84,6 +86,7 @@ If you set `measurement` parameter, use its value instead of event tag.
   dbname test
   user  testuser
   password  mypwd
+  auth_method basic_auth
   use_ssl false
   time_precision s
   tag_keys ["key1", "key2"]

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -20,6 +20,8 @@ class Fluent::Plugin::InfluxdbOutput < Fluent::Plugin::Output
 The database name of influxDB.
 You should create the database and grant permissions at first.
 DESC
+  config_param :skip_db_check, :string, default: false,
+               desc: "Skip checking if database exists before attempting to write"
   config_param :measurement, :string, default: nil,
                desc: "The measurement name to insert events. If not specified, fluentd's tag is used"
   config_param :user, :string,  default: 'root',
@@ -96,7 +98,7 @@ DESC
     begin
       existing_databases = @influxdb.list_databases.map { |x| x['name'] }
       unless existing_databases.include? @dbname
-        raise Fluent::ConfigError, 'Database ' + @dbname + ' doesn\'t exist. Create it first, please. Existing databases: ' + existing_databases.join(',')
+        raise Fluent::ConfigError, 'Database ' + @dbname + ' doesn\'t exist. Create it first, please. Existing databases: ' + existing_databases.join(',') unless @skip_db_check
       end
     rescue InfluxDB::AuthenticationError, InfluxDB::Error
       log.info "skip database presence check because '#{@user}' user doesn't have admin privilege. Check '#{@dbname}' exists on influxdb"

--- a/lib/fluent/plugin/out_influxdb.rb
+++ b/lib/fluent/plugin/out_influxdb.rb
@@ -26,6 +26,8 @@ DESC
                desc: "The DB user of influxDB, should be created manually."
   config_param :password, :string,  default: 'root', secret: true,
                desc: "The password of the user."
+  config_param :auth_method, :string,  default: 'params',
+               desc: "The authentication method. Default is 'param'"
   config_param :retry, :integer, default: nil,
                desc: 'The finite number of retry times. default is infinite'
   config_param :time_key, :string, default: 'time',
@@ -84,6 +86,7 @@ DESC
                                                 port: @port,
                                                 username: @user,
                                                 password: @password,
+                                                auth_method: @auth_method,
                                                 async: false,
                                                 retry: @retry,
                                                 time_precision: @time_precision,


### PR DESCRIPTION
First, the [Telegraf InfluxDB Input Plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb_listener) only supports basic auth requests, but the Influxdb ruby client defaults to parameter-based authentication, so this fluent-plugin-influxdb library only uses parameter based authentication. 

By leveraging a new configuration option, [auth_method](https://github.com/influxdata/influxdb-ruby/blob/e8fdec6fa38ae5a1f64cd10369cae6d9c93738c9/lib/influxdb/client/http.rb#L77-L79), this plugin can be configured make basic_auth requests instead.

Second, once you're able to authenticate to the Telegraf influxdb_listener, you need to skip checking whether the destination DB exists. The influxdb_listener accepts /write requests for any database name, so `skip_db_check` should be set to "true" if that is your destination.


_____

The ability to use basic auth may also be viewed as a security benefit.  Since any web proxy (and maybe even InfluxDB's own request logging, I didn't check) will record the username and password parameters in plain text, this plugin may unintentionally leak passwords.  I chose to leave the default auth_method as a parameter to avoid making a breaking change, and defer to the maintainers to switch the default if desired.
