### PR TITLE
Update influxdb supported version range to support Ruby 3.x

### DIFF
--- a/fluent-plugin-influxdb.gemspec
+++ b/fluent-plugin-influxdb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fluentd", [">= 1.0", "< 2"]
-  s.add_runtime_dependency "influxdb", [">= 0.7.0", "< 0.8"]
+  s.add_runtime_dependency "influxdb", [">= 0.7.0", "< 0.9"]
 
   s.add_development_dependency "rake"
   s.add_development_dependency "pry"


### PR DESCRIPTION
The handling of keyword arguments has changed significantly in Ruby 3.0. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Unfortunately, the dependent influxdb gem v0.7.0 has occured the error by this change. If influxdb gem will be updated to v0.8.1, this error will be resolved. https://github.com/InfluxCommunity/influxdb-ruby/blob/master/CHANGELOG.md#v081-release-2021-02-17

So, this patch will update supported influxdb version range.

Fix https://github.com/fangli/fluent-plugin-influxdb/issues/110

### reproduce
```
<source>
  @type sample
  tag test
</source>

<match **>
  @type influxdb
  host "127.0.0.1"
  port 8086
  dbname "macaDB"
  user "admin"
  password xxxxxx
  time_precision "s"
  measurement "server_list"
  tag_keys ["hostname"]
  <buffer>
    flush_interval 5s
  </buffer>
</match>
```

```
$ fluentd -c tmp.conf
   (snip)
2024-09-26 16:35:20 +0900 [info]: #0 starting fluentd worker pid=123174 ppid=123151 worker=0
2024-09-26 16:35:20 +0900 [info]: #0 Connecting to database: macaDB, host: 127.0.0.1, port: 8086, username: admin, use_ssl = false, verify_ssl = true
2024-09-26 16:35:20 +0900 [error]: #0 unexpected error error_class=ArgumentError error="wrong number of arguments (given 1, expected 0)"
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/influxdb-0.7.0/lib/influxdb/config.rb:73:in `initialize'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/influxdb-0.7.0/lib/influxdb/client.rb:54:in `new'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/influxdb-0.7.0/lib/influxdb/client.rb:54:in `initialize'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluent-plugin-influxdb-2.0.0/lib/fluent/plugin/out_influxdb.rb:83:in `new'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluent-plugin-influxdb-2.0.0/lib/fluent/plugin/out_influxdb.rb:83:in `start'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/root_agent.rb:203:in `block in start'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/root_agent.rb:192:in `block (2 levels) in lifecycle'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/root_agent.rb:191:in `each'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/root_agent.rb:191:in `block in lifecycle'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/root_agent.rb:178:in `each'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/root_agent.rb:178:in `lifecycle'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/root_agent.rb:202:in `start'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/engine.rb:248:in `start'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/engine.rb:147:in `run'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/supervisor.rb:617:in `block in run_worker'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/supervisor.rb:962:in `main_process'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/supervisor.rb:608:in `run_worker'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/lib/fluent/command/fluentd.rb:372:in `<top (required)>'
  2024-09-26 16:35:20 +0900 [error]: #0 <internal:/home/watson/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
  2024-09-26 16:35:20 +0900 [error]: #0 <internal:/home/watson/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/fluentd-1.17.1/bin/fluentd:15:in `<top (required)>'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/bin/fluentd:25:in `load'
  2024-09-26 16:35:20 +0900 [error]: #0 /home/watson/.rbenv/versions/3.3.5/bin/fluentd:25:in `<main>'
   (snip)

```